### PR TITLE
Update Test Runner and Robotium version

### DIFF
--- a/RoboRemoteClient/pom.xml
+++ b/RoboRemoteClient/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteclient</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <name>RoboRemote Client</name>
     <description>This is the desktop side component of RoboRemote</description>
 
@@ -61,7 +61,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/RoboRemoteClientCommon/pom.xml
+++ b/RoboRemoteClientCommon/pom.xml
@@ -35,7 +35,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteclientcommon</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <name>RoboRemote Client Common Library</name>
     <description>This is the desktop side common client component</description>
 
@@ -60,7 +60,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/RoboRemoteClientJUnit/pom.xml
+++ b/RoboRemoteClientJUnit/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.groupon.roboremote.roboremoteclient</groupId>
     <artifactId>junit</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <name>RoboRemote Client JUnit</name>
     <description>This is the junit portion of the desktop side component of RoboRemote</description>
 
@@ -60,7 +60,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/RoboRemoteConstants/pom.xml
+++ b/RoboRemoteConstants/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteconstants</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>RoboRemote Constants Library</name>
     <description>This is the constants library for RoboRemote</description>
@@ -61,7 +61,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/RoboRemoteServer/aar/pom.xml
+++ b/RoboRemoteServer/aar/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteserveraar</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <packaging>aar</packaging>
     <name>RoboRemoteServer AAR</name>
     <description>This is the Android side component of RoboRemote</description>
@@ -58,13 +58,19 @@
     <parent>
         <groupId>com.groupon.roboremote</groupId>
         <artifactId>roboremoteserveraggregator</artifactId>
-        <version>0.6.0-b14-SNAPSHOT</version>
+        <version>0.6.1-b1-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+        </dependency>
+        <dependency>
             <groupId>com.jayway.android.robotium</groupId>
             <artifactId>robotium-solo</artifactId>
+            <version>5.4.1</version>
         </dependency>
         <dependency>
             <groupId>android</groupId>
@@ -75,6 +81,18 @@
             <groupId>com.google.android</groupId>
             <artifactId>android-test</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>runner</artifactId>
+            <version>0.3</version>
+            <type>aar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>rules</artifactId>
+            <version>0.3</version>
+            <type>aar</type>
         </dependency>
         <dependency>
             <groupId>com.googlecode.json-simple</groupId>
@@ -115,7 +133,7 @@
                         </jvmArguments>
                     </dex>
                     <sdk>
-                        <platform>14</platform>
+                        <platform>17</platform>
                     </sdk>
                     <androidManifestFile>../apklib/AndroidManifest.xml</androidManifestFile>
                     <resourceDirectory>../apklib/res</resourceDirectory>

--- a/RoboRemoteServer/apklib/pom.xml
+++ b/RoboRemoteServer/apklib/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteserver</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <packaging>apklib</packaging>
     <name>RoboRemoteServer APKLib</name>
     <description>This is the Android side component of RoboRemote</description>
@@ -58,18 +58,31 @@
     <parent>
         <groupId>com.groupon.roboremote</groupId>
         <artifactId>roboremoteserveraggregator</artifactId>
-        <version>0.6.0-b14-SNAPSHOT</version>
+        <version>0.6.1-b1-SNAPSHOT</version>
     </parent>
 
     <dependencies>
         <dependency>
             <groupId>com.jayway.android.robotium</groupId>
             <artifactId>robotium-solo</artifactId>
+            <version>5.4.1</version>
         </dependency>
         <dependency>
             <groupId>android</groupId>
             <artifactId>android</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>runner</artifactId>
+            <version>0.3</version>
+            <type>aar</type>
+        </dependency>
+        <dependency>
+            <groupId>com.android.support.test</groupId>
+            <artifactId>rules</artifactId>
+            <version>0.3</version>
+            <type>aar</type>
         </dependency>
         <dependency>
             <groupId>com.google.android</groupId>
@@ -115,7 +128,7 @@
                         </jvmArguments>
                     </dex>
                     <sdk>
-                        <platform>14</platform>
+                        <platform>17</platform>
                     </sdk>
                 </configuration>
                 <extensions>true</extensions>

--- a/RoboRemoteServer/apklib/src/main/com/groupon/roboremote/roboremoteserver/RemoteTest.java
+++ b/RoboRemoteServer/apklib/src/main/com/groupon/roboremote/roboremoteserver/RemoteTest.java
@@ -32,23 +32,32 @@
 
 package com.groupon.roboremote.roboremoteserver;
 
-import android.content.Context;
-import android.content.SharedPreferences;
-import android.preference.PreferenceManager;
-import android.test.ActivityInstrumentationTestCase2;
+import org.junit.Before;
+import org.junit.Rule;
 import android.app.Activity;
+import android.app.Instrumentation;
 import com.groupon.roboremote.Constants;
 import com.groupon.roboremote.roboremoteserver.robotium.*;
 
-public abstract class RemoteTest<T extends Activity> extends ActivityInstrumentationTestCase2 {
+import android.support.test.InstrumentationRegistry;
+import android.support.test.rule.ActivityTestRule;
+
+public abstract class RemoteTest<T extends Activity> {
     protected Solo2 solo;
     private Object lastResponseObject = null;
     private Boolean appStarted = false;
     private RoboRemoteServer rrs = null;
 
+    @Rule
+    public ActivityTestRule<T> mActivityRule;
+
     public RemoteTest(Class<T> activityClass) throws ClassNotFoundException {
-        super("blah", activityClass);
         rrs = new RoboRemoteServer(null, getInstrumentation(), this);
+        mActivityRule = new ActivityTestRule(activityClass);
+    }
+
+    public Instrumentation getInstrumentation() {
+        return InstrumentationRegistry.getInstrumentation();
     }
 
     public void startServer() throws Exception {
@@ -64,14 +73,13 @@ public abstract class RemoteTest<T extends Activity> extends ActivityInstrumenta
 
     public void startApp() {
         // Initialize Robotium Solo singleton
-        solo = new Solo2(getInstrumentation(), getActivity());
+        solo = new Solo2(getInstrumentation());//, mActivityRule.getActivity());
         SoloSingleton.set(solo);
         rrs.setSolo(solo);
     }
 
-    @Override
-    protected void setUp() throws Exception {
-        super.setUp();
+    @Before
+    public void setup() throws Exception {
         startApp();
     }
 }

--- a/RoboRemoteServer/apklib/src/main/com/groupon/roboremote/roboremoteserver/RemoteTestRunner.java
+++ b/RoboRemoteServer/apklib/src/main/com/groupon/roboremote/roboremoteserver/RemoteTestRunner.java
@@ -33,9 +33,10 @@
 package com.groupon.roboremote.roboremoteserver;
 
 import android.os.Bundle;
-import android.test.InstrumentationTestRunner;
 
-public class RemoteTestRunner extends InstrumentationTestRunner {
+import android.support.test.runner.AndroidJUnitRunner;
+
+public class RemoteTestRunner extends AndroidJUnitRunner {
     @Override
     public void onCreate(Bundle arguments) {
         //process you parameters here.

--- a/RoboRemoteServer/apklib/src/main/com/groupon/roboremote/roboremoteserver/robotium/Solo2.java
+++ b/RoboRemoteServer/apklib/src/main/com/groupon/roboremote/roboremoteserver/robotium/Solo2.java
@@ -38,7 +38,7 @@ import android.content.ComponentName;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.*;
-import com.jayway.android.robotium.solo.Solo;
+import com.robotium.solo.Solo;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;

--- a/RoboRemoteServer/pom.xml
+++ b/RoboRemoteServer/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteserveraggregator</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>RoboRemoteServer Aggregator</name>
     <description>This is the aggregator for RoboRemoteServer</description>
@@ -63,7 +63,7 @@
 
     
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->
@@ -75,12 +75,12 @@
           <dependency>
               <groupId>com.jayway.android.robotium</groupId>
               <artifactId>robotium-solo</artifactId>
-              <version>4.3.1</version>
+              <version>5.4.1</version>
           </dependency>
           <dependency>
               <groupId>android</groupId>
               <artifactId>android</artifactId>
-              <version>4.2.2_r2</version>
+              <version>4.2.2_r3</version>
               <scope>provided</scope>
           </dependency>
           <dependency>

--- a/RoboRemoteServerCommon/pom.xml
+++ b/RoboRemoteServerCommon/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteservercommon</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>RoboRemote Server Common Library</name>
     <description>This is the common remote server library</description>
@@ -62,7 +62,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->
@@ -73,7 +73,7 @@
         <dependency>
             <groupId>android</groupId>
             <artifactId>android</artifactId>
-            <version>4.2.2_r2</version>
+            <version>4.2.2_r3</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/UIAutomatorClient/pom.xml
+++ b/UIAutomatorClient/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>uiautomatorclient</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <name>UiAutomator Client</name>
     <description>This is the desktop side component of UIAutomator Remote</description>
 
@@ -61,7 +61,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/UIAutomatorServer/pom.xml
+++ b/UIAutomatorServer/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>uiautomatorserver</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <packaging>apk</packaging>
     <name>RoboRemote UIAutomator Server</name>
     <description>This is the Android side component of RoboRemote</description>
@@ -30,7 +30,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->
@@ -41,13 +41,13 @@
         <dependency>
             <groupId>android.test.uiautomator</groupId>
             <artifactId>uiautomator</artifactId>
-            <version>4.4.2_r3</version>
+            <version>4.4.2_r4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>android</groupId>
             <artifactId>android</artifactId>
-            <version>4.3_r2</version>
+            <version>4.4.2_r4</version>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremote</artifactId>
-    <version>0.6.0-b14-SNAPSHOT</version>
+    <version>0.6.1-b1-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>RoboRemote</name>
     <description>This is the aggregator for RoboRemote</description>


### PR DESCRIPTION
-updated RemoteTestRunner to use AndroidJUnitRunner instead of InstrumentationTestRunner
-updated Robotium to 5.4.1 which apparently has fixed some activity related instabilities.
-updated RemoteTest to junit4 style test
-updated version to 0.6.1-b1