### PR TITLE
0.6.1-b3: Do not adb push jars if they are already present on the device

### DIFF
--- a/RoboRemoteClient/pom.xml
+++ b/RoboRemoteClient/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteclient</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <name>RoboRemote Client</name>
     <description>This is the desktop side component of RoboRemote</description>
 
@@ -61,7 +61,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/RoboRemoteClientCommon/pom.xml
+++ b/RoboRemoteClientCommon/pom.xml
@@ -35,7 +35,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteclientcommon</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <name>RoboRemote Client Common Library</name>
     <description>This is the desktop side common client component</description>
 
@@ -60,7 +60,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/RoboRemoteClientCommon/src/main/com/groupon/roboremote/roboremoteclientcommon/Utils.java
+++ b/RoboRemoteClientCommon/src/main/com/groupon/roboremote/roboremoteclientcommon/Utils.java
@@ -135,6 +135,22 @@ public class Utils {
         }
     }
 
+  /**
+   * Check if file exists on device at /data/local/tmp location
+   * @param jarFile - jar File name to check
+   *
+   * @return true if file exists
+   * @throws Exception
+   */
+  public static boolean fileExistsOnDevice(String jarFile) throws Exception {
+      String lsResult = executeLocalCommand(new String[] {"adb", "-s", DebugBridge.get().getSerialNumber(), "shell", "ls", "/data/local/tmp |", "grep", jarFile});
+         if(lsResult.contains(jarFile)){
+           return true;
+    }
+
+       return false;
+  }
+
     public static void addADBTunnelWithPIDFile(String type, int port) throws Exception {
         DebugBridge.get().createTunnel(port, port);
         DebugBridge.get().runShellCommand("touch /data/local/tmp/" + type + "_PORT_" + port);

--- a/RoboRemoteClientCommon/src/main/com/groupon/roboremote/roboremoteclientcommon/Utils.java
+++ b/RoboRemoteClientCommon/src/main/com/groupon/roboremote/roboremoteclientcommon/Utils.java
@@ -143,12 +143,16 @@ public class Utils {
    * @throws Exception
    */
   public static boolean fileExistsOnDevice(String jarFile) throws Exception {
-      String lsResult = executeLocalCommand(new String[] {"adb", "-s", DebugBridge.get().getSerialNumber(), "shell", "ls", "/data/local/tmp |", "grep", jarFile});
-         if(lsResult.contains(jarFile)){
-           return true;
-    }
+      String lsResult = executeLocalCommand(new String[] {"adb", "-s", DebugBridge.get().getSerialNumber(), "shell", "ls", "/data/local/tmp"});
+      String[] lsResults = lsResult.split(System.getProperty("line.separator"));
+      for (String file : lsResults) {
+          if (file.contains(jarFile)) {
+             logger.info("Found file at /data/local/tmp :" + jarFile);
+             return true;
+          }
+     }
 
-       return false;
+     return false;
   }
 
     public static void addADBTunnelWithPIDFile(String type, int port) throws Exception {

--- a/RoboRemoteClientCommon/src/main/com/groupon/roboremote/roboremoteclientcommon/Utils.java
+++ b/RoboRemoteClientCommon/src/main/com/groupon/roboremote/roboremoteclientcommon/Utils.java
@@ -36,9 +36,11 @@ import org.json.JSONArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.*;
-import java.lang.Exception;
-import java.lang.String;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStreamReader;
 import java.net.ServerSocket;
 import java.util.ArrayList;
 import java.util.Map;
@@ -134,26 +136,6 @@ public class Utils {
             }
         }
     }
-
-  /**
-   * Check if file exists on device at /data/local/tmp location
-   * @param jarFile - jar File name to check
-   *
-   * @return true if file exists
-   * @throws Exception
-   */
-  public static boolean fileExistsOnDevice(String jarFile) throws Exception {
-      String lsResult = executeLocalCommand(new String[] {"adb", "-s", DebugBridge.get().getSerialNumber(), "shell", "ls", "/data/local/tmp"});
-      String[] lsResults = lsResult.split(System.getProperty("line.separator"));
-      for (String file : lsResults) {
-          if (file.contains(jarFile)) {
-             logger.info("Found file at /data/local/tmp :" + jarFile);
-             return true;
-          }
-     }
-
-     return false;
-  }
 
     public static void addADBTunnelWithPIDFile(String type, int port) throws Exception {
         DebugBridge.get().createTunnel(port, port);

--- a/RoboRemoteClientJUnit/pom.xml
+++ b/RoboRemoteClientJUnit/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.groupon.roboremote.roboremoteclient</groupId>
     <artifactId>junit</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <name>RoboRemote Client JUnit</name>
     <description>This is the junit portion of the desktop side component of RoboRemote</description>
 
@@ -60,7 +60,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/RoboRemoteConstants/pom.xml
+++ b/RoboRemoteConstants/pom.xml
@@ -35,7 +35,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteconstants</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>RoboRemote Constants Library</name>
     <description>This is the constants library for RoboRemote</description>
@@ -61,7 +61,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/RoboRemoteServer/aar/pom.xml
+++ b/RoboRemoteServer/aar/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteserveraar</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <packaging>aar</packaging>
     <name>RoboRemoteServer AAR</name>
     <description>This is the Android side component of RoboRemote</description>
@@ -58,7 +58,7 @@
     <parent>
         <groupId>com.groupon.roboremote</groupId>
         <artifactId>roboremoteserveraggregator</artifactId>
-        <version>0.6.1-b1-SNAPSHOT</version>
+        <version>0.6.1-b3-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/RoboRemoteServer/apklib/pom.xml
+++ b/RoboRemoteServer/apklib/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteserver</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <packaging>apklib</packaging>
     <name>RoboRemoteServer APKLib</name>
     <description>This is the Android side component of RoboRemote</description>
@@ -58,7 +58,7 @@
     <parent>
         <groupId>com.groupon.roboremote</groupId>
         <artifactId>roboremoteserveraggregator</artifactId>
-        <version>0.6.1-b1-SNAPSHOT</version>
+        <version>0.6.1-b3-SNAPSHOT</version>
     </parent>
 
     <dependencies>

--- a/RoboRemoteServer/pom.xml
+++ b/RoboRemoteServer/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteserveraggregator</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>RoboRemoteServer Aggregator</name>
     <description>This is the aggregator for RoboRemoteServer</description>
@@ -63,7 +63,7 @@
 
     
     <properties>
-        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/RoboRemoteServerCommon/pom.xml
+++ b/RoboRemoteServerCommon/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremoteservercommon</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>RoboRemote Server Common Library</name>
     <description>This is the common remote server library</description>
@@ -62,7 +62,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/UIAutomatorClient/pom.xml
+++ b/UIAutomatorClient/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>uiautomatorclient</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <name>UiAutomator Client</name>
     <description>This is the desktop side component of UIAutomator Remote</description>
 
@@ -61,7 +61,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/UIAutomatorClient/src/main/com/groupon/roboremote/uiautomatorclient/TestBase.java
+++ b/UIAutomatorClient/src/main/com/groupon/roboremote/uiautomatorclient/TestBase.java
@@ -31,14 +31,13 @@
  */
 
 package com.groupon.roboremote.uiautomatorclient;
-
 import com.android.ddmlib.MultiLineReceiver;
 import com.groupon.roboremote.roboremoteclientcommon.DebugBridge;
 import com.groupon.roboremote.roboremoteclientcommon.Device;
 import com.groupon.roboremote.roboremoteclientcommon.Utils;
+import com.groupon.roboremote.roboremoteclientcommon.logging.*;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import com.groupon.roboremote.roboremoteclientcommon.logging.*;
 
 import java.io.File;
 import java.lang.Exception;
@@ -157,17 +156,20 @@ public class TestBase {
     public void deployTestJar() throws Exception {
         // we build a new list of jars that will be used for the launch command line
         _automator_run_jars = new ArrayList<String>();
-
         for (String jarFileName: _automator_jars) {
             File jarFile = new File(jarFileName);
             if (!jarFile.exists())
                 throw new Exception("Test jar does not exist: " + _automator_jar);
 
             String[] destFileNameParts = jarFileName.split(File.separator);
-            String destFileName = "/data/local/tmp/" + destFileNameParts[destFileNameParts.length-1];
+            String destFileName = "/data/local/tmp/" + destFileNameParts[destFileNameParts.length - 1];
             _automator_run_jars.add(destFileName);
 
-            DebugBridge.get().push(jarFileName, destFileName);
+            // do adb push to /data/local/tmp if file does not exist on device
+            if(!Utils.fileExistsOnDevice(destFileNameParts[destFileNameParts.length - 1])) {
+                logger.info("Push file to device :" + destFileName);
+                DebugBridge.get().push(jarFileName, destFileName);
+            }
         }
     }
 

--- a/UIAutomatorClient/src/main/com/groupon/roboremote/uiautomatorclient/TestBase.java
+++ b/UIAutomatorClient/src/main/com/groupon/roboremote/uiautomatorclient/TestBase.java
@@ -69,15 +69,17 @@ public class TestBase {
      * @param clearAppData - true if you want app data cleared, false otherwise
      */
     public void setUp(String testName, Boolean clearAppData) throws Exception {
-        if (_automator_jars == null)
-            setAppEnvironmentVariables();
+        if (_automator_jars == null) {
+             setAppEnvironmentVariables();
+            // push files to device only once at the beginning after setting the App environment variables
+            deployTestJar();
+        }
 
         // only do the following if isStarted==false OR the client is not already listening
         // this allows a client that overrides this class to safely call setUp multiple times without destroying logs
         if (!isStarted || !Client.getInstance().isListening()) {
             logger.info("Starting test {}", testName);
             Device.setupLogDirectories(testName);
-            deployTestJar();
 
             // see if a server is already listening
             boolean clientWasListening = false;
@@ -165,11 +167,9 @@ public class TestBase {
             String destFileName = "/data/local/tmp/" + destFileNameParts[destFileNameParts.length - 1];
             _automator_run_jars.add(destFileName);
 
-            // do adb push to /data/local/tmp if file does not exist on device
-            if(!Utils.fileExistsOnDevice(destFileNameParts[destFileNameParts.length - 1])) {
-                logger.info("Push file to device :" + destFileName);
-                DebugBridge.get().push(jarFileName, destFileName);
-            }
+            logger.info("Push file to device :" + destFileName);
+            DebugBridge.get().push(jarFileName, destFileName);
+
         }
     }
 

--- a/UIAutomatorServer/pom.xml
+++ b/UIAutomatorServer/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>uiautomatorserver</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <packaging>apk</packaging>
     <name>RoboRemote UIAutomator Server</name>
     <description>This is the Android side component of RoboRemote</description>
@@ -30,7 +30,7 @@
     </parent>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.1-b1-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->

--- a/examples/HelloWorld/Tests/pom.xml
+++ b/examples/HelloWorld/Tests/pom.xml
@@ -41,7 +41,7 @@
     <version>1.0</version>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
     </properties>
 
     <parent>

--- a/examples/HelloWorld/helloworldtestrunner/pom.xml
+++ b/examples/HelloWorld/helloworldtestrunner/pom.xml
@@ -43,7 +43,7 @@
     <name>Runner</name>
 
     <properties>
-        <com.groupon.roboremote-version>0.6.0-b14-SNAPSHOT</com.groupon.roboremote-version>
+        <com.groupon.roboremote-version>0.6.1-b3-SNAPSHOT</com.groupon.roboremote-version>
 
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <!-- Disable kicking off tests during build. Can do this through command line with : -Dandroid.enableIntegrationTest=true -->
@@ -68,6 +68,11 @@
     </repositories>
 
     <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+        </dependency>
         <dependency>
             <groupId>com.google.android</groupId>
             <artifactId>android</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
 
     <groupId>com.groupon.roboremote</groupId>
     <artifactId>roboremote</artifactId>
-    <version>0.6.1-b1-SNAPSHOT</version>
+    <version>0.6.1-b3-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>RoboRemote</name>
     <description>This is the aggregator for RoboRemote</description>


### PR DESCRIPTION

In UIAutomatorTestBase Setup, we deploy Test Jars: (adb push) for each test case.This is unnecessary .
Added a check to push so that deployTestJar executes only once

Updated the version to 0.6.1-b3-SNAPSHOT

Fixed the Poms for example directory

mvn clean install under robo-remote

